### PR TITLE
Add devcontainer template metadata

### DIFF
--- a/src/python313/devcontainer-template.json
+++ b/src/python313/devcontainer-template.json
@@ -2,7 +2,7 @@
     "id": "python313",
     "version": "1.0.0",
     "name": "Python 3.13 Base",
-    "description": "Python 3.13 dev container with Node.js, AWS CLI, CDK, Docker CLI, tmux, and Zsh configured via dotfiles.",
+    "description": "Python 3.13 dev container",
     "documentationURL": "https://github.com/blackwd/dev-container/tree/main/src/python313",
     "publisher": "blackwd",
     "licenseURL": "https://github.com/blackwd/dev-container/blob/main/LICENSE",

--- a/src/python313/devcontainer-template.json
+++ b/src/python313/devcontainer-template.json
@@ -1,0 +1,11 @@
+{
+    "id": "python313",
+    "version": "1.0.0",
+    "name": "Python 3.13 Base",
+    "description": "Python 3.13 dev container with Node.js, AWS CLI, CDK, Docker CLI, tmux, and Zsh configured via dotfiles.",
+    "documentationURL": "https://github.com/blackwd/dev-container/tree/main/src/python313",
+    "publisher": "blackwd",
+    "licenseURL": "https://github.com/blackwd/dev-container/blob/main/LICENSE",
+    "platforms": ["Python"],
+    "optionalPaths": []
+}


### PR DESCRIPTION
## Summary
- add `devcontainer-template.json` to describe the Python 3.13 template

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68478478a3688327b14dcdf7fb8c9964